### PR TITLE
Feature/implement tag deploy (#7)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
               file(credentialsId: 'mmpl-backend-production-django', variable: 'DJANGO_SECRETS_PATH'),
               usernamePassword(credentialsId: 'aws-ecr-pusher', passwordVariable: 'AWS_SECRET_ACCESS_KEY', usernameVariable: 'AWS_ACCESS_KEY_ID')
             ]) {
-              env.DEPLOY_HOST = "staging.mmpl.systemiphus.com"
+              env.DEPLOY_HOST = "mmpl.systemiphus.com"
               sh './build-scripts/production/deploy.sh'
             }
           }

--- a/mmpl_backend/__init__.py
+++ b/mmpl_backend/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.0.1"
 __version_info__ = tuple(
     [
         int(num) if num.isdigit() else num

--- a/mmpl_backend/templates/base.html
+++ b/mmpl_backend/templates/base.html
@@ -83,7 +83,7 @@
       {% endif %}
 
       {% block content %}
-        <p>Ben is a fucking legend. Conditional scripted build!</p>
+        <p>Ben is a fucking legend. Full multi host master and tag pipeline!!!</p>
       {% endblock content %}
 
     </div> <!-- /container -->


### PR DESCRIPTION
* Add host param to deploy script, add scripted pipeline section to Jenkins pipeline to delineate between master and a tag.

* Fix issue with script block

* Testing actual deploy and build

* Ensure cleanup scripts exit with 1 status

* Trying another method to stop the tag running

* Move back to master as the conditional.

* Add new mmpl host for production (tag) deploy

* Change the deployment file to prove it works

* Move the build to the right tag version